### PR TITLE
[第七組]Refactor/naming conventions

### DIFF
--- a/backend/.scannerwork/report-task.txt
+++ b/backend/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=PriceTracker
+serverUrl=http://localhost:9000
+serverVersion=10.7.0.96327
+dashboardUrl=http://localhost:9000/dashboard?id=PriceTracker
+ceTaskId=e590c344-5b5e-40fe-9c5c-e622226390a0
+ceTaskUrl=http://localhost:9000/api/ce/task?id=e590c344-5b5e-40fe-9c5c-e622226390a0

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,9 +158,9 @@ def get_new_info(search_term, is_initial=False):
     # iterate pages to get more news data, not actually get all news data
     if is_initial:
         a = []
-        for p in range(1, 10):
+        for pages in range(1, 10):
             p2 = {
-                "page": p,
+                "page": pages,
                 "id": f"search:{quote(search_term)}",
                 "channelId": 2,
                 "type": "searchword",
@@ -171,7 +171,7 @@ def get_new_info(search_term, is_initial=False):
         for l in a:
             all_news_data.append(l)
     else:
-        p = {
+        pages = {
             "page": 1,
             "id": f"search:{quote(search_term)}",
             "channelId": 2,
@@ -214,9 +214,9 @@ def get_new(is_initial=False):
             content_section = soup.find("section", class_="article-content__editor")
 
             paragraphs = [
-                p.text
-                for p in content_section.find_all("p")
-                if p.text.strip() != "" and "▪" not in p.text
+                pages.text
+                for pages in content_section.find_all("pages")
+                if pages.text.strip() != "" and "▪" not in pages.text
             ]
             detailed_news =  {
                 "url": news["titleLink"],
@@ -432,9 +432,9 @@ async def search_news(request: PromptRequest):
             content_section = soup.find("section", class_="article-content__editor")
 
             paragraphs = [
-                p.text
-                for p in content_section.find_all("p")
-                if p.text.strip() != "" and "▪" not in p.text
+                pages.text
+                for pages in content_section.find_all("pages")
+                if pages.text.strip() != "" and "▪" not in pages.text
             ]
             detailed_news = {
                 "url": news["titleLink"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -146,10 +146,21 @@ def add_new(news_data):
     session.close()
 
 
+
+def get_news_data(search_term, page, channel_id=2):
+    pagedata = {
+        "page": page,
+        "id": f"search:{quote(search_term)}",
+        "channelId": channel_id,
+        "type": "searchword",
+    }
+    response = requests.get("https://udn.com/api/more", params=pagedata)
+    response.raise_for_status() 
+    return response.json().get("lists", [])
+
 def get_new_info(search_term, is_initial=False):
     """
     get new
-
     :param search_term:
     :param is_initial:
     :return:
@@ -157,35 +168,16 @@ def get_new_info(search_term, is_initial=False):
     all_news_data = []
     # iterate pages to get more news data, not actually get all news data
     if is_initial:
-        a = []
         for pages in range(1, 10):
-            p2 = {
-                "page": pages,
-                "id": f"search:{quote(search_term)}",
-                "channelId": 2,
-                "type": "searchword",
-            }
-            response = requests.get("https://udn.com/api/more", params=p2)
-            a.append(response.json()["lists"])
-
-        for l in a:
-            all_news_data.append(l)
+            page_data = get_news_data(search_term, pages)
+            all_news_data.extend(page_data)    
     else:
-        pages = {
-            "page": 1,
-            "id": f"search:{quote(search_term)}",
-            "channelId": 2,
-            "type": "searchword",
-        }
-        response = requests.get("https://udn.com/api/more", params=p)
-
-        all_news_data = response.json()["lists"]
+        all_news_data = get_news_data(search_term, page=1)
     return all_news_data
 
 def get_new(is_initial=False):
     """
     get new info
-
     :param is_initial:
     :return:
     """

--- a/backend/main.py
+++ b/backend/main.py
@@ -74,7 +74,7 @@ sentry_sdk.init(
 )
 
 app = FastAPI()
-bgs = BackgroundScheduler()
+Scheduler=BackgroundScheduler()
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 app.add_middleware(
@@ -250,13 +250,13 @@ def start_scheduler():
         # should change into simple factory pattern
         get_new()
     db.close()
-    bgs.add_job(get_new, "interval", minutes=100)
-    bgs.start()
+    Scheduler.add_job(get_new, "interval", minutes=100)
+    Scheduler.start()
 
 
 @app.on_event("shutdown")
 def shutdown_scheduler():
-    bgs.shutdown()
+    Scheduler.shutdown()
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from sqlalchemy import (Column, ForeignKey, Integer, String, Table, Text,
                         create_engine)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
-
+from datetime import datetime, timedelta, timezone  
 Base = declarative_base()
 
 
@@ -295,9 +295,9 @@ def create_access_token(data, expires_delta=None):
     """create access token"""
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     print(to_encode)
     encoded_jwt = jwt.encode(to_encode, '1892dhianiandowqd0n', algorithm="HS256")


### PR DESCRIPTION
這次重構提高了代碼的可讀性，具體表現在：

重命名變數以增強清晰度（例如，OuO 改為 user，u 改為 usertoken，n_id 改為 articlesid）。
新增 get_pages_info 函數來處理新聞數據的獲取，以避免代碼重複。