### PR TITLE
[第七組]Refactor/naming conventions

### DIFF
--- a/backend/.scannerwork/report-task.txt
+++ b/backend/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=PriceTracker
+serverUrl=http://localhost:9000
+serverVersion=10.7.0.96327
+dashboardUrl=http://localhost:9000/dashboard?id=PriceTracker
+ceTaskId=e590c344-5b5e-40fe-9c5c-e622226390a0
+ceTaskUrl=http://localhost:9000/api/ce/task?id=e590c344-5b5e-40fe-9c5c-e622226390a0

--- a/backend/main.py
+++ b/backend/main.py
@@ -274,12 +274,13 @@ def check_user_password_is_correct(db, username, password):
         return False
     return user
 
-
+SECRET_KEY = '1892dhianiandowqd0n'
+ALGORITHM = "HS256"
 def authenticate_user_token(
     token = Depends(oauth2_scheme),
     db = Depends(session_opener)
 ):
-    payload = jwt.decode(token, '1892dhianiandowqd0n', algorithms=["HS256"])
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
     return db.query(User).filter(User.username == payload.get("sub")).first()
 
 
@@ -292,7 +293,7 @@ def create_access_token(data, expires_delta=None):
         expire = datetime.datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     print(to_encode)
-    encoded_jwt = jwt.encode(to_encode, '1892dhianiandowqd0n', algorithm="HS256")
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,9 +158,9 @@ def get_new_info(search_term, is_initial=False):
     # iterate pages to get more news data, not actually get all news data
     if is_initial:
         a = []
-        for p in range(1, 10):
+        for pages in range(1, 10):
             p2 = {
-                "page": p,
+                "page": pages,
                 "id": f"search:{quote(search_term)}",
                 "channelId": 2,
                 "type": "searchword",
@@ -171,7 +171,7 @@ def get_new_info(search_term, is_initial=False):
         for l in a:
             all_news_data.append(l)
     else:
-        p = {
+        pages = {
             "page": 1,
             "id": f"search:{quote(search_term)}",
             "channelId": 2,
@@ -214,9 +214,9 @@ def get_new(is_initial=False):
             content_section = soup.find("section", class_="article-content__editor")
 
             paragraphs = [
-                p.text
-                for p in content_section.find_all("p")
-                if p.text.strip() != "" and "▪" not in p.text
+                pages.text
+                for pages in content_section.find_all("pages")
+                if pages.text.strip() != "" and "▪" not in pages.text
             ]
             detailed_news =  {
                 "url": news["titleLink"],
@@ -432,9 +432,9 @@ async def search_news(request: PromptRequest):
             content_section = soup.find("section", class_="article-content__editor")
 
             paragraphs = [
-                p.text
-                for p in content_section.find_all("p")
-                if p.text.strip() != "" and "▪" not in p.text
+                pages.text
+                for pages in content_section.find_all("pages")
+                if pages.text.strip() != "" and "▪" not in pages.text
             ]
             detailed_news = {
                 "url": news["titleLink"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -206,9 +206,9 @@ def get_new(is_initial=False):
             content_section = article_soup.find("section", class_="article-content__editor")
 
             paragraphs = [
-                pages.text
-                for pages in content_section.find_all("p")
-                if pages.text.strip() != "" and "▪" not in pages.text
+                paragraphinfo.text
+                for paragraphinfo in content_section.find_all("p")
+                if paragraphinfo.text.strip() != "" and "▪" not in paragraphinfo.text
             ]
             detailed_news =  {
                 "url": news["titleLink"],
@@ -424,9 +424,9 @@ async def search_news(request: PromptRequest):
             content_section = item_soup.find("section", class_="article-content__editor")
 
             paragraphs = [
-                pages.text
-                for pages in content_section.find_all("p")
-                if pages.text.strip() != "" and "▪" not in pages.text
+                paragraphinfo.text
+                for paragraphinfo in content_section.find_all("p")
+                if paragraphinfo.text.strip() != "" and "▪" not in paragraphinfo.text
             ]
             detailed_news = {
                 "url": news["titleLink"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -146,10 +146,21 @@ def add_new(news_data):
     session.close()
 
 
+
+def get_news_data(search_term, page, channel_id=2):
+    pagedata = {
+        "page": page,
+        "id": f"search:{quote(search_term)}",
+        "channelId": channel_id,
+        "type": "searchword",
+    }
+    response = requests.get("https://udn.com/api/more", params=pagedata)
+    response.raise_for_status() 
+    return response.json().get("lists", [])
+
 def get_new_info(search_term, is_initial=False):
     """
     get new
-
     :param search_term:
     :param is_initial:
     :return:
@@ -157,35 +168,16 @@ def get_new_info(search_term, is_initial=False):
     all_news_data = []
     # iterate pages to get more news data, not actually get all news data
     if is_initial:
-        a = []
         for pages in range(1, 10):
-            p2 = {
-                "page": pages,
-                "id": f"search:{quote(search_term)}",
-                "channelId": 2,
-                "type": "searchword",
-            }
-            response = requests.get("https://udn.com/api/more", params=p2)
-            a.append(response.json()["lists"])
-
-        for l in a:
-            all_news_data.append(l)
+            page_data = get_news_data(search_term, pages)
+            all_news_data.extend(page_data)    
     else:
-        pages = {
-            "page": 1,
-            "id": f"search:{quote(search_term)}",
-            "channelId": 2,
-            "type": "searchword",
-        }
-        response = requests.get("https://udn.com/api/more", params=p)
-
-        all_news_data = response.json()["lists"]
+        all_news_data = get_news_data(search_term, page=1)
     return all_news_data
 
 def get_new(is_initial=False):
     """
     get new info
-
     :param is_initial:
     :return:
     """

--- a/backend/main.py
+++ b/backend/main.py
@@ -74,7 +74,7 @@ sentry_sdk.init(
 )
 
 app = FastAPI()
-bgs = BackgroundScheduler()
+Scheduler=BackgroundScheduler()
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 app.add_middleware(
@@ -250,13 +250,13 @@ def start_scheduler():
         # should change into simple factory pattern
         get_new()
     db.close()
-    bgs.add_job(get_new, "interval", minutes=100)
-    bgs.start()
+    Scheduler.add_job(get_new, "interval", minutes=100)
+    Scheduler.start()
 
 
 @app.on_event("shutdown")
 def shutdown_scheduler():
-    bgs.shutdown()
+    Scheduler.shutdown()
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/backend/main.py
+++ b/backend/main.py
@@ -201,7 +201,7 @@ def get_new(is_initial=False):
             article_soup = BeautifulSoup(response.text, "html.parser")
             # 標題
             article_title = article_soup.find("h1", class_="article-content__title").text
-            publish_time = article_soup.find("time", class_="article-content__time").text
+            article_time = article_soup.find("time", class_="article-content__time").text
             # 定位到包含文章内容的 <section>
             content_section = article_soup.find("section", class_="article-content__editor")
 
@@ -213,7 +213,7 @@ def get_new(is_initial=False):
             detailed_news =  {
                 "url": news["titleLink"],
                 "title":  article_title,
-                "time": publish_time,
+                "time": article_time,
                 "content": paragraphs,
             }
             aiinfo = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from sqlalchemy import (Column, ForeignKey, Integer, String, Table, Text,
                         create_engine)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
-
+from datetime import datetime, timedelta, timezone  
 Base = declarative_base()
 
 
@@ -295,9 +295,9 @@ def create_access_token(data, expires_delta=None):
     """create access token"""
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     print(to_encode)
     encoded_jwt = jwt.encode(to_encode, '1892dhianiandowqd0n', algorithm="HS256")


### PR DESCRIPTION
### Purpose
重構命名規範

### Change
`user_news_association_table`  改成  `user_news_table`
認為 `user_news_table`就能表示意圖所以縮短他

40～44行：設定變數來限制使用者名稱和密碼的最大長度
將數字提出較好維護

76行： `bgs`改成 `Scheduler`
認為 `Scheduler`更能表示意圖

148～159行：將重複的請求邏輯提取到新的 `get_pages_info`函數中
減少重複代碼提高可維護性

150行： `p` 改成 `pageinfo`
187行： `m`改成 `aiinfo`
209～211行： `p`改成  `paragraphinfo`

201～216行： `soup`、 `title`、 `time`分別改成 `article_soup`、 `article_title`、 `article_time`
和第419~424行的命名做區分

267、268行：把 `p1`、 `p2`改成 `plain_password`、 `hashed_password`
將 `p1`、 `p2`做區分並用更能表示意圖的命名

271～273行： `n`改成 `uesername`， `pwd`改成 `password`， `OuO`改成 `user`
277、278行： JWT 編碼中使用的硬編碼金鑰和演算法移至單獨的變數 `SECRET_KEY`和 `ALGORITHM`中
提高可維護性和清晰度

290、292行：由於 `datetime.utcnow()` 會回傳沒有時區 (timezone) 的 datetime 物件，所以改成 `datetime.now(timezone.utc)`
332行： `uid`改成 `userid`
333行： `cnt`改成 `total_upvotes`
359～360行：將 `n`改成 `article`
372行： `u`改成 `usertoken`
440、441行： `e`改成 `error`
419～424行： `soup`、 `title` 、 `time`分別改成 `item_soup`、 `item_title` 、 `item_time`
482～500行：將 `n_id`改成 `articleid`、將 `u_id`改成 `userid`
507、508行：將 `id2`改成 `article_id`