### PR TITLE
[第七組]Refactor/overall

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
       - 'develop'
-      - 'refactor/error_handling'
+      - 'refactor/overall'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,15 @@ jobs:
           .\venv\Scripts\activate
           cd backend
           pytest tests/llm_clients --cov=src --cov-report=xml --disable-warnings
+      
+      - name: Run database tests
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+
+        .\venv\Scripts\activate
+        cd backend
+        pytest tests/database --cov=src --cov-report=xml --disable-warnings
 
       - name: Run integration tests (with mock DB)
         env:
@@ -73,6 +82,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage.xml
+
+
 
 #  lint:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,13 +61,12 @@ jobs:
           pytest tests/llm_clients --cov=src --cov-report=xml --disable-warnings
       
       - name: Run database tests
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      run: |
-
-        .\venv\Scripts\activate
-        cd backend
-        pytest tests/database --cov=src --cov-report=xml --disable-warnings
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          .\venv\Scripts\activate
+          cd backend
+          pytest tests/database --cov=src --cov-report=xml --disable-warnings
 
       - name: Run integration tests (with mock DB)
         env:

--- a/backend/src/auth/services.py
+++ b/backend/src/auth/services.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta, timezone
 from jose import jwt
 from fastapi import Depends
 from sentry_sdk import capture_exception
-import logging
 from .config import SECRET_KEY, ALGORITHM, TOKEN_EXPIRE_TIME
 from .utils import verify
 from ..database import oauth2_scheme, session_opener

--- a/backend/src/crawler/udn_crawler.py
+++ b/backend/src/crawler/udn_crawler.py
@@ -38,7 +38,8 @@ import requests
 from bs4 import BeautifulSoup
 from sqlalchemy.orm import Session
 from urllib.parse import quote
-from .crawler_base import NewsCrawlerBase, Headline, News, NewsWithSummary
+from .crawler_base import NewsCrawlerBase, Headline, News
+from ..models import NewsArticle
 from requests import Response
 from .exceptions import InvalidSearchTermException, InvalidPageException, ParseException, SaveException
 from ..logger.base import logger
@@ -174,7 +175,7 @@ class UDNCrawler(NewsCrawlerBase):
             capture_exception(e)
             raise ParseException(url=url, message=str(e))
 
-    def save(self, news_data: NewsWithSummary, db: Session):
+    def save(self, news_data: NewsArticle, db: Session):
         try:
             db.add(news_data)
             self._commit_changes(db)

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -16,6 +16,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=Database.TOKENURl)
 
 def session_opener():
+    session=None
     try:
         session = Session(bind=engine)
         yield session
@@ -24,4 +25,5 @@ def session_opener():
         capture_exception(e)
         raise DatabaseConnectionError(f"Database connection error: {str(e)}")
     finally:
-        session.close()
+        if session: 
+            session.close()

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -3,15 +3,25 @@ from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.ext.declarative import declarative_base
 from fastapi.security import OAuth2PasswordBearer
 from .config import Database
+from .logger.base import logger
+from sentry_sdk import capture_exception
+from .exceptions import DatabaseConnectionError
+
+
 Base = declarative_base()
 engine = create_engine("sqlite:///news_database.db", echo=True)
 Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=Database.TOKENURl)
+
 def session_opener():
-    session = Session(bind=engine)
     try:
+        session = Session(bind=engine)
         yield session
+    except Exception as e:
+        logger.error(f"Database connection error: {str(e)}")
+        capture_exception(e)
+        raise DatabaseConnectionError(f"Database connection error: {str(e)}")
     finally:
         session.close()

--- a/backend/src/exceptions.py
+++ b/backend/src/exceptions.py
@@ -13,3 +13,13 @@ class SchedulerShutdownError(MainException):
     """Exception raised when scheduler shutdown fails"""
     def __init__(self, message: str = "Scheduler shutdown failed"):
         super().__init__(message)
+class DatabaseException(Exception):
+    """Base exception class for database operations"""
+    def __init__(self, message: str = "Database operation error"):
+        self.message = message
+        super().__init__(self.message)
+
+class DatabaseConnectionError(DatabaseException):
+    """Database connection exception"""
+    def __init__(self, message: str = "Database connection failed"):
+        super().__init__(message)

--- a/backend/src/llm_clients/Templete.py
+++ b/backend/src/llm_clients/Templete.py
@@ -55,7 +55,7 @@ class LLMClientTemplate(LLMClientBase, ABC):
         try:
             completion = self.client.chat.completions.create(
                 model=self.model,
-                messages=self._llm_messages(system_content, user_content)
+                messages=self._generate_mpi_messages(system_content, user_content)
             )
             logger.info("Successfully generated text response")
             return completion.choices[0].message.content
@@ -64,7 +64,7 @@ class LLMClientTemplate(LLMClientBase, ABC):
             capture_exception(e)
             raise TextGenerationError(f"Failed to generate text: {str(e)}")
 
-    def _llm_messages(self, system_content: str, user_content: str) -> list:
+    def _generate_mpi_messages(self, system_content: str, user_content: str) -> list:
         try:
             if system_content is None or user_content is None:
                 raise MessageFormatError("系統內容或使用者內容不能為空")

--- a/backend/src/llm_clients/Templete.py
+++ b/backend/src/llm_clients/Templete.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
 from .config import SystemContent
-from .llm_base import LLMClientBase, MessagePassingInterface
-from .exceptions import ClientException, MessageValidationError, MessageFormatError, TextGenerationError
-import aisuite as ai
+from .llm_base import LLMClientBase
+from .exceptions import MessageFormatError, TextGenerationError
 from sentry_sdk import capture_exception
 from ..logger.base import logger
-
+import aisuite as ai
 system_content=SystemContent()
 
 class LLMClientTemplate(LLMClientBase, ABC):
@@ -13,62 +12,67 @@ class LLMClientTemplate(LLMClientBase, ABC):
     def __init__(self,api_key:str):
         self.api_key=api_key
         self._initialize_client()
-
+        logger.info("LLM client template initialized")
+        
     @abstractmethod
-    def _initialize_client(self):        
-        pass
-    
+    def _initialize_client(self, model_name: str, key_name: str):
+        self.client = ai.Client({model_name: {"api_key": self.api_key}})
+
     def evaluate_relevance(self, title):
         try:
             messages=system_content.MESSAGES_FOR_RELEVANCE
-            ai_info=self._generate_MPI_dict(messages, title)
-            return self._generate_text(messages=ai_info)
+            result = self._generate_text(messages,title)
+            logger.info(f"Successfully evaluated relevance for title: {title}")
+            return result
         except Exception as e:
-            logger.error(f"Failed to evaluate relevance: {str(e)}")
+            logger.error(f"Failed to evaluate relevance for title {title}: {str(e)}")
             capture_exception(e)
-            raise TextGenerationError(f"Failed to evaluate relevance: {str(e)}")
+            raise
 
     def generate_summary(self, content):
         try:
             messages=system_content.MESSAGES_FOR_GENERATE_SUMMARY
-            ai_info=self._generate_MPI_dict(messages, content)
-            return self._generate_text(messages=ai_info)
+            result = self._generate_text(messages,content)
+            logger.info("Successfully generated summary")
+            return result
         except Exception as e:
             logger.error(f"Failed to generate summary: {str(e)}")
             capture_exception(e)
-            raise TextGenerationError(f"Failed to generate summary: {str(e)}")
+            raise
 
     def extract_search_keywords(self,content):
         try:
             messages=system_content.MESSAGES_FOR_KEYWORDS
-            ai_info=self._generate_MPI_dict(messages, content)
-            return self._generate_text(messages=ai_info)
+            result = self._generate_text(messages,content)
+            logger.info("Successfully extracted search keywords")
+            return result
         except Exception as e:
-            logger.error(f"Failed to extract keywords: {str(e)}")
+            logger.error(f"Failed to extract search keywords: {str(e)}")
             capture_exception(e)
-            raise TextGenerationError(f"Failed to extract keywords: {str(e)}")
+            raise
  
-    def _generate_text(self,messages):
+    def _generate_text(self,system_content,user_content):
         try:
             completion = self.client.chat.completions.create(
                 model=self.model,
-                messages=messages,
+                messages=self._llm_messages(system_content, user_content)
             )
+            logger.info("Successfully generated text response")
             return completion.choices[0].message.content
         except Exception as e:
             logger.error(f"Failed to generate text: {str(e)}")
             capture_exception(e)
             raise TextGenerationError(f"Failed to generate text: {str(e)}")
 
-    def _generate_MPI_dict(self, system_content, user_content):
+    def _llm_messages(self, system_content: str, user_content: str) -> list:
         try:
-            mpi = MessagePassingInterface(system_content=system_content, user_content=user_content)
-            return mpi.to_dict
-        except (MessageValidationError, MessageFormatError) as e:
-            logger.error(f"Message format validation failed: {str(e)}")
-            capture_exception(e)
-            raise e
+            messages = [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content}
+            ]
+            logger.debug("Successfully formatted LLM messages")
+            return messages
         except Exception as e:
-            logger.error(f"Failed to generate message format: {str(e)}")
+            logger.error(f"Failed to format LLM messages: {str(e)}")
             capture_exception(e)
-            raise TextGenerationError(f"Failed to generate message format: {str(e)}")
+            raise MessageFormatError(f"Failed to format messages: {str(e)}")

--- a/backend/src/llm_clients/Templete.py
+++ b/backend/src/llm_clients/Templete.py
@@ -66,6 +66,8 @@ class LLMClientTemplate(LLMClientBase, ABC):
 
     def _llm_messages(self, system_content: str, user_content: str) -> list:
         try:
+            if system_content is None or user_content is None:
+                raise MessageFormatError("系統內容或使用者內容不能為空")
             messages = [
                 {"role": "system", "content": system_content},
                 {"role": "user", "content": user_content}

--- a/backend/src/llm_clients/anthropic_clients.py
+++ b/backend/src/llm_clients/anthropic_clients.py
@@ -1,22 +1,8 @@
 from .Templete import LLMClientTemplate
 from .config import ANTHROPIC_MODEL
-import aisuite as ai
-from .exceptions import ClientException
 from ..logger.base import logger
-from sentry_sdk import capture_exception
 
-
-class AnthropicClient(LLMClientTemplate):
-    def __init__(self, api_key: str):
-        super().__init__(api_key)
-        logger.info("Initializing Anthropic client")
-        
+class AnthropicClient(LLMClientTemplate):  
     def _initialize_client(self):
-        try:
-            self.client = ai.Client({"anthropic": {"api_key": self.api_key}})
-            self.model = ANTHROPIC_MODEL
-            logger.info("Successfully initialized Anthropic client")
-        except Exception as e:
-            logger.error(f"Failed to initialize Anthropic client: {str(e)}")
-            capture_exception(e)
-            raise ClientException(f"Failed to initialize client: {str(e)}")
+        super()._initialize_client("anthropic", ANTHROPIC_MODEL)
+        self.model = ANTHROPIC_MODEL

--- a/backend/src/llm_clients/llm_base.py
+++ b/backend/src/llm_clients/llm_base.py
@@ -1,32 +1,6 @@
 import abc
-import logging
-from sentry_sdk import capture_exception
-from pydantic import BaseModel, Field
 import aisuite as ai
-from .exceptions import MessageValidationError, MessageFormatError
 from ..logger.base import logger
-
-class MessagePassingInterface(BaseModel):
-    system_content: str = Field(...)
-    user_content: str = Field(...)
-
-    @property
-    def to_dict(self) -> list[dict[str, str]]:
-        try:
-            if not self.system_content or not self.user_content:
-                raise MessageValidationError("System content or user content cannot be empty")
-            
-            dicts = [
-                {"role": "system", "content": f"{self.system_content}"},
-                {"role": "user", "content": f"{self.user_content}"}
-            ]
-            return dicts
-        except Exception as e:
-            logger.error(f"Error in message format conversion: {str(e)}")
-            capture_exception(e)
-            raise MessageFormatError(f"Error occurred while converting message format: {str(e)}")
-
-
 
 class LLMClientBase(metaclass=abc.ABCMeta):
     client: ai.Client = ...

--- a/backend/src/llm_clients/openai_clients.py
+++ b/backend/src/llm_clients/openai_clients.py
@@ -1,20 +1,8 @@
 from .Templete import LLMClientTemplate
 from .config import GPT_MODEL
-import aisuite as ai
-from .exceptions import ClientException
-from sentry_sdk import capture_exception
 from ..logger.base import logger
 
 class OpenAIClient(LLMClientTemplate):
-    def __init__(self, api_key: str):
-        super().__init__(api_key)
-        
     def _initialize_client(self):
-        try:
-            self.client = ai.Client({"openai": {"api_key": self.api_key}})
-            self.model = GPT_MODEL
-            logger.info("OpenAI client initialized successfully")
-        except Exception as e:
-            logger.error(f"Failed to initialize OpenAI client: {str(e)}")
-            capture_exception(e)
-            raise ClientException(f"Failed to initialize client: {str(e)}")
+        super()._initialize_client("openai", GPT_MODEL)
+        self.model = GPT_MODEL

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -11,7 +11,7 @@ from .news.router import router as news_router
 from .users.router import router as users_router
 from .exceptions import SchedulerStartupError, SchedulerShutdownError
 from .logger.base import logger
-from sentry_sdk import capture_exception, capture_message
+from sentry_sdk import capture_exception
 
 sentry_sdk.init(
     dsn=App.DSN,

--- a/backend/src/news/exceptions.py
+++ b/backend/src/news/exceptions.py
@@ -1,37 +1,28 @@
 class NewsServiceException(Exception):
     """Base exception class for news service"""
     def __init__(self, message: str = "News service error"):
-        self.message = message
-        super().__init__(self.message)
+        super().__init__(message)
 
 class NewsAddException(NewsServiceException):
     """Exception when adding news"""
     def __init__(self, message: str = "Failed to add news"):
         super().__init__(message)
-
-class NewsRetrievalException(NewsServiceException):
-    """Exception when retrieving news"""
-    def __init__(self, message: str = "Failed to retrieve news"):
-        super().__init__(message)
-
 class UpvoteOperationException(NewsServiceException):
     """Exception when upvoting"""
     def __init__(self, message: str = "Failed to upvote"):
         super().__init__(message)
-class NewsSearchException(Exception):
+
+class NewsSearchException(NewsServiceException):
     """Exception when searching news"""
     def __init__(self, message: str = "Failed to search news"):
-        self.message = message
-        super().__init__(self.message)
+        super().__init__(message)
 
-class NewsSummaryException(Exception):
+class NewsSummaryException(NewsServiceException):
     """Exception when generating news summary"""
     def __init__(self, message: str = "Failed to generate news summary"):
-        self.message = message
-        super().__init__(self.message)
+        super().__init__(message)
 
-class UpvoteException(Exception):
+class UpvoteException(NewsServiceException):
     """Exception when upvoting"""
     def __init__(self, message: str = "Failed to upvote"):
-        self.message = message
-        super().__init__(self.message)
+        super().__init__(message)

--- a/backend/src/news/router.py
+++ b/backend/src/news/router.py
@@ -76,16 +76,11 @@ def upvote_article(
 
 @router.post("/news_summary_custom_model")
 async def summarize_news_with_custome_model(payload: NewsSumaryCustomModelSchema, user_token= Depends(authenticate_user_token)):
-    
     llm_client = None
     if payload.llm_model == "anthropic":
         llm_client = services.anthropic_client
     elif payload.llm_model == "openai":
         llm_client = services.openai_client
-    if not llm_client:
-        logger.error(f"Invalid AI model specified: {payload.llm_model}")
-        capture_exception(f"Invalid AI model specified: {payload.llm_model}")
-        raise NewsSummaryException("Invalid AI model specified")
     result = services.get_news_summary(payload,user_token,llm_client)
     return result
 

--- a/backend/src/news/router.py
+++ b/backend/src/news/router.py
@@ -75,7 +75,7 @@ def upvote_article(
     return services.upvote_article(article_id,db,usertoken)
 
 @router.post("/news_summary_custom_model")
-async def summarize_news_with_custome_model(payload: NewsSumaryCustomModelSchema, user_token= Depends(authenticate_user_token)):
+async def summarize_news_with_custom_model(payload: NewsSumaryCustomModelSchema, user_token= Depends(authenticate_user_token)):
     llm_client = None
     if payload.llm_model == "anthropic":
         llm_client = services.anthropic_client

--- a/backend/src/news/router.py
+++ b/backend/src/news/router.py
@@ -1,24 +1,16 @@
-import itertools
-import requests
-import json
-from fastapi import Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from ..database import session_opener
 from ..auth.services import authenticate_user_token
-from ..models import NewsArticle
-from .services import get_article_upvote_details, get_new_info, toggle_upvote,openai_client, anthropic_client
-from .schemas import PromptRequest, NewsSumaryRequestSchema, NewsSumaryCustomModelSchema
-from fastapi import APIRouter
+from .schemas import PromptRequest, NewsSumaryRequestSchema
 from ..crawler.udn_crawler import UDNCrawler
-from ..crawler.exceptions import ParseException
-from ..llm_clients.exceptions import TextGenerationError
-from .exceptions import NewsSearchException, NewsSummaryException, UpvoteException
+from ..crawler.crawler_base import NewsCrawlerBase
+from . import services
+from .schemas import NewsSumaryCustomModelSchema
 from ..logger.base import logger
 from sentry_sdk import capture_exception
-from .exceptions import NewsSummaryException, UpvoteException
-
-
+from .exceptions import NewsSummaryException
 udn_crawler=UDNCrawler()
-llm_client=openai_client
+
 
 router = APIRouter(
     prefix="/news",
@@ -32,19 +24,7 @@ def read_news(db=Depends(session_opener)):
     :param db:
     :return:包含新聞文章及其點贊詳情的列表
     """
-    try:
-        news = db.query(NewsArticle).order_by(NewsArticle.time.desc()).all()
-        result = []
-        for article in news:
-            upvotes, upvoted = get_article_upvote_details(article.id, None, db)
-            result.append(
-                {**article.__dict__, "upvotes": upvotes, "is_upvoted": upvoted}
-            )
-        return result
-    except Exception as e:
-        logger.error(f"Failed to get news: {str(e)}")
-        capture_exception(e)
-        raise HTTPException(status_code=500, detail=str(e))
+    return services.read_news_with_details(db,None)
 
 @router.get("/user_news")
 def read_user_news(
@@ -57,66 +37,20 @@ def read_user_news(
     :param usertoken:
     :return:包含點讚詳情的新聞文章列表
     """
-    try:
-        news = db.query(NewsArticle).order_by(NewsArticle.time.desc()).all()
-        result = []
-        for article in news:
-            upvotes, upvoted = get_article_upvote_details(article.id, usertoken.id, db)
-            result.append(
-                {
-                    **article.__dict__,
-                    "upvotes": upvotes,
-                    "is_upvoted": upvoted,
-                }
-            )
-        return result
-    except Exception as e:
-        logger.error(f"Failed to get user news: {str(e)}")
-        capture_exception(e)
-        raise HTTPException(status_code=500, detail=str(e))
+    return services.read_news_with_details(db,usertoken)
 
-_id_counter = itertools.count(start=1000000)
+
 @router.post("/search_news")
 async def search_news(request: PromptRequest):
     """
     :param request: `PromptRequest` 類型的請求對象，包含使用者輸入的新聞描述文字 (prompt)
     :return: JSON 格式的新聞列表
     """
-    try:
-        news_list = []
-        keywords = llm_client.extract_search_keywords(request.prompt)
-        news_items = get_new_info(keywords, is_initial=False)
-        for news in news_items:
-            try:
-                news_from_crawler=udn_crawler.parse(news.url)
-                content = news_from_crawler.content
-               
-                detailed_news = {
-                    "url": news.url,
-                    "title": news.title,
-                    "time": news_from_crawler.time,
-                    "content": content,
-                }
-                detailed_news["id"]  = next(_id_counter)
-
-                news_list.append(detailed_news)
-            except ParseException as error:
-                logger.error(f"Failed to parse news: {str(error)}")
-                capture_exception(error)
-                continue
-        return sorted(news_list, key=lambda x: x["time"], reverse=True)
-    except TextGenerationError as e:
-        logger.error(f"Failed to extract keywords: {str(e)}")
-        capture_exception(e)
-        raise NewsSearchException(f"Failed to extract keywords: {str(e)}")
-    except Exception as e:
-        logger.error(f"Failed to search news: {str(e)}")
-        capture_exception(e)
-        raise NewsSearchException(str(e))
+    return services.search_news(request)
 
 @router.post("/news_summary")
 async def news_summary(
-        payload: NewsSumaryRequestSchema, user=Depends(authenticate_user_token)
+        payload: NewsSumaryRequestSchema, user_token=Depends(authenticate_user_token)
 ):
     """
     這個 API 端點接收新聞內容，並生成一個包含新聞影響和原因的摘要
@@ -124,26 +58,7 @@ async def news_summary(
     :param user: 經由 `authenticate_user_token` 認證的使用者。
     :return: JSON 格式的摘要結果
     """
-    try:
-        response = {}
-        result = llm_client.generate_summary(payload.content)
-        if result:
-            result = json.loads(result)
-            response["summary"] = result["影響"]
-            response["reason"] = result["原因"]
-        return response
-    except TextGenerationError as e:
-        logger.error(f"Failed to generate summary: {str(e)}")
-        capture_exception(e)
-        raise NewsSummaryException(f"Failed to generate summary: {str(e)}")
-    except json.JSONDecodeError as e:
-        logger.error(f"Invalid summary format: {str(e)}")
-        capture_exception(e)
-        raise NewsSummaryException("Invalid summary format")
-    except Exception as e:
-        logger.error(f"Error occurred during summary generation: {str(e)}")
-        capture_exception(e)
-        raise NewsSummaryException(str(e))
+    return services.get_news_summary(payload,user_token,services.openai_client)
 
 @router.post("/{article_id}/upvote")
 def upvote_article(
@@ -157,41 +72,22 @@ def upvote_article(
     :param usertoken:
     :return: JSON 格式的點讚操作狀態訊息
     """
-    try:
-        message = toggle_upvote(article_id, usertoken.id, db)
-        return {"message": message}
-    except Exception as e:
-        logger.error(f"Failed to upvote: {str(e)}")
-        capture_exception(e)
-        raise UpvoteException(str(e))
+    return services.upvote_article(article_id,db,usertoken)
 
 @router.post("/news_summary_custom_model")
-async def summarize_news_with_custome_model(payload: NewsSumaryCustomModelSchema, user= Depends(authenticate_user_token)):
-    try:
-        response = {}
-        if(payload.ai_model=="anthropic") :
-            llm_client=anthropic_client
-        if(payload.ai_model=="openai") :
-            llm_client=openai_client 
-        result = llm_client.generate_summary(payload.content)
-        if result:
-            result = json.loads(result)
-            response["summary"] = result["影響"]
-            response["reason"] = result["原因"]
-        return response
-    except TextGenerationError as e:
-        logger.error(f"Custom model failed to generate summary: {str(e)}")
-        capture_exception(e)
-        raise NewsSummaryException(f"Failed to generate summary: {str(e)}")
-    except json.JSONDecodeError as e:
-        logger.error(f"Custom model invalid summary format: {str(e)}")
-        capture_exception(e)
-        raise NewsSummaryException("Invalid summary format")
-    except Exception as e:
-        logger.error(f"Error occurred during custom model summary generation: {str(e)}")
-        capture_exception(e)
-        raise NewsSummaryException(str(e))
+async def summarize_news_with_custome_model(payload: NewsSumaryCustomModelSchema, user_token= Depends(authenticate_user_token)):
+    
+    llm_client = None
+    if payload.llm_model == "anthropic":
+        llm_client = services.anthropic_client
+    elif payload.llm_model == "openai":
+        llm_client = services.openai_client
+    if not llm_client:
+        logger.error(f"Invalid AI model specified: {payload.llm_model}")
+        capture_exception(f"Invalid AI model specified: {payload.llm_model}")
+        raise NewsSummaryException("Invalid AI model specified")
+    result = services.get_news_summary(payload,user_token,llm_client)
+    return result
 
-@router.get("/sentry-debug")
-async def trigger_error():
-    division_by_zero = 1 / 0
+    
+

--- a/backend/src/news/schemas.py
+++ b/backend/src/news/schemas.py
@@ -1,8 +1,9 @@
 from pydantic import BaseModel
+from typing import Literal
 class PromptRequest(BaseModel):
     prompt: str
 class NewsSumaryRequestSchema(BaseModel):
     content: str
 class NewsSumaryCustomModelSchema(BaseModel):
     content: str
-    ai_model: str   
+    llm_model: Literal["openai", "anthropic"]

--- a/backend/src/news/services.py
+++ b/backend/src/news/services.py
@@ -2,14 +2,10 @@ from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import delete, insert, select
 import itertools
-import json
-import requests
-from ..auth.services import authenticate_user_token
-from ..database import session_opener
 from ..models import user_news_table, NewsArticle
 from ..logger.base import logger
 from ..crawler.udn_crawler import UDNCrawler
-from ..crawler.crawler_base import NewsWithSummary, NewsCrawlerBase
+from ..crawler.crawler_base import NewsWithSummary
 from ..crawler.exceptions import ParseException
 from ..llm_clients.openai_clients import OpenAIClient
 from ..llm_clients.anthropic_clients import AnthropicClient
@@ -17,7 +13,6 @@ from ..llm_clients.exceptions import TextGenerationError
 from .config import OPENAI_API_KEY, ANTHROPIC_KEY
 from .exceptions import (
     NewsAddException,
-    NewsRetrievalException,
     NewsSearchException,
     NewsServiceException,
     UpvoteException,
@@ -26,6 +21,7 @@ from .exceptions import (
 )
 from .router import PromptRequest
 from sentry_sdk import capture_exception
+import json
 
 # 初始化客戶端
 udn_crawler = UDNCrawler()
@@ -95,15 +91,10 @@ def get_new_info(search_term, is_initial=False):
     :param is_initial:是否獲取多個頁面的新聞資料
     :return:包含新聞資料的列表
     """
-    try:
-        if is_initial:  
-            return udn_crawler.get_headline(search_term,page=(1,10))    
-        else:
-            return udn_crawler.get_headline(search_term,1) 
-    except Exception as e:
-        logger.error(f"Failed to get news info: {str(e)}")
-        capture_exception(e)
-        raise NewsRetrievalException(f"Failed to get news info: {str(e)}")
+    if is_initial:  
+        return udn_crawler.get_headline(search_term,page=(1,10))    
+    else:
+        return udn_crawler.get_headline(search_term,1) 
 
 def get_new(is_initial=False):
     """
@@ -111,29 +102,26 @@ def get_new(is_initial=False):
     :param is_initial:是否需要抓取多頁的新聞
     :return:
     """
-    try:
-        news_data = get_new_info("price", is_initial=is_initial)
-        for news in news_data:
-            title = news.title
-            url=news.url
-            relevance = openai_client.evaluate_relevance(title)
-            if relevance == "high":
-                news_from_crawler=udn_crawler.parse(url)
-                result = openai_client.generate_summary(news_from_crawler.content)
-                result = json.loads(result)
-                detailed_news=NewsArticle(
-                    title=title,
-                    url=url,
-                    time=news_from_crawler.time,
-                    content=news_from_crawler.content,
-                    summary=result["影響"],
-                    reason=result["原因"]
-                )
-                add_new(detailed_news)
-    except Exception as e:
-        logger.error(f"Failed to process news data: {str(e)}")
-        capture_exception(e)
-        raise NewsRetrievalException(f"Failed to process news data: {str(e)}")
+    
+    news_data = get_new_info("price", is_initial=is_initial)
+    for news in news_data:
+        title = news.title
+        url=news.url
+        relevance = openai_client.evaluate_relevance(title)
+        if relevance == "high":
+            news_from_crawler=udn_crawler.parse(url)
+            result = openai_client.generate_summary(news_from_crawler.content)
+            result = json.loads(result)
+            detailed_news=NewsArticle(
+                title=title,
+                url=url,
+                time=news_from_crawler.time,
+                content=news_from_crawler.content,
+                summary=result["影響"],
+                reason=result["原因"]
+            )
+            add_new(detailed_news)
+
 
 def get_article_upvote_details(article_id, userid, db):
     try:

--- a/backend/src/news/services.py
+++ b/backend/src/news/services.py
@@ -1,21 +1,77 @@
+from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import delete, insert, select
+import itertools
 import json
-from ..models import user_news_table, NewsArticle
-from .config import OPENAI_API_KEY, ANTHROPIC_KEY
-from ..crawler.udn_crawler import UDNCrawler
-from ..crawler.crawler_base import NewsWithSummary
-from ..crawler.crawler_base import NewsCrawlerBase
 import requests
+from ..auth.services import authenticate_user_token
+from ..database import session_opener
+from ..models import user_news_table, NewsArticle
+from ..logger.base import logger
+from ..crawler.udn_crawler import UDNCrawler
+from ..crawler.crawler_base import NewsWithSummary, NewsCrawlerBase
+from ..crawler.exceptions import ParseException
 from ..llm_clients.openai_clients import OpenAIClient
 from ..llm_clients.anthropic_clients import AnthropicClient
-from ..logger.base import logger
+from ..llm_clients.exceptions import TextGenerationError
+from .config import OPENAI_API_KEY, ANTHROPIC_KEY
+from .exceptions import (
+    NewsAddException,
+    NewsRetrievalException,
+    NewsSearchException,
+    NewsServiceException,
+    UpvoteException,
+    UpvoteOperationException,
+    NewsSummaryException,
+)
+from .router import PromptRequest
 from sentry_sdk import capture_exception
 
+# 初始化客戶端
 udn_crawler = UDNCrawler()
-openai_client = OpenAIClient(api_key= OPENAI_API_KEY)
+openai_client = OpenAIClient(api_key=OPENAI_API_KEY)
 anthropic_client = AnthropicClient(api_key=ANTHROPIC_KEY)
-from .exceptions import NewsAddException, NewsRetrievalException, UpvoteOperationException, NewsServiceException
+_id_counter = itertools.count(start=1000000)
+llm_client=OpenAIClient(api_key= OPENAI_API_KEY)
+
+def search_news(request: PromptRequest):
+    try:
+        news_list = []
+        keywords = llm_client.extract_search_keywords(request.prompt)
+        news_items = get_new_info(keywords, is_initial=False)
+        for news in news_items:
+            try:
+                detailed_news = udn_crawler.validate_and_parse(news.url).model_dump()
+                detailed_news["id"]  = next(_id_counter)
+                news_list.append(detailed_news)
+            except ParseException as error:
+                logger.error(f"Failed to parse news: {str(error)}")
+                capture_exception(error)
+                continue
+        return sorted(news_list, key=lambda x: x["time"], reverse=True)
+    except TextGenerationError as e:
+        logger.error(f"Failed to extract keywords: {str(e)}")
+        capture_exception(e)
+        raise NewsSearchException(f"Failed to extract keywords: {str(e)}")
+    except Exception as e:
+        logger.error(f"Failed to search news: {str(e)}")
+        capture_exception(e)
+        raise NewsSearchException(str(e))
+    
+def read_news_with_details(db, usertoken):
+    try:
+        news = db.query(NewsArticle).order_by(NewsArticle.time.desc()).all()
+        result = []
+        for article in news:
+            upvotes, upvoted = get_article_upvote_details(article.id, usertoken.id if usertoken else None, db)
+            result.append(
+                {**article.__dict__, "upvotes": upvotes, "is_upvoted": upvoted}
+            )
+        return result
+    except Exception as e:
+        logger.error(f"Failed to get news: {str(e)}")
+        capture_exception(e)
+        raise HTTPException(status_code=500, detail=str(e))
 
 def add_new(news_data: NewsWithSummary):
     """
@@ -65,7 +121,7 @@ def get_new(is_initial=False):
                 news_from_crawler=udn_crawler.parse(url)
                 result = openai_client.generate_summary(news_from_crawler.content)
                 result = json.loads(result)
-                detailed_news=NewsWithSummary(
+                detailed_news=NewsArticle(
                     title=title,
                     url=url,
                     time=news_from_crawler.time,
@@ -80,12 +136,6 @@ def get_new(is_initial=False):
         raise NewsRetrievalException(f"Failed to process news data: {str(e)}")
 
 def get_article_upvote_details(article_id, userid, db):
-    """
-    :param article_id: 
-    :param userid: 
-    :param db: 資料庫的 session
-    :return: (點贊總數, 當前使用者是否已點贊)
-    """
     try:
         total_upvotes = (
             db.query(user_news_table)
@@ -148,3 +198,32 @@ def news_exists(article_id, db: Session):
         logger.error(f"Failed to check if news exists: {str(e)}")
         capture_exception(e)
         raise NewsServiceException(f"Failed to check if news exists: {str(e)}")
+def upvote_article(article_id, db, usertoken):
+    try:
+        message = toggle_upvote(article_id, usertoken.id, db)
+        return {"message": message}
+    except Exception as e:
+        logger.error(f"Failed to upvote: {str(e)}")
+        capture_exception(e)
+        raise UpvoteException(str(e))
+def get_news_summary(payload,user_token,llm_client):
+    try:
+        response = {}
+        result = llm_client.generate_summary(payload.content)
+        if result:
+            result = json.loads(result)
+            response["summary"] = result["影響"]
+            response["reason"] = result["原因"]
+        return response
+    except TextGenerationError as e:
+        logger.error(f"Failed to generate summary: {str(e)}")
+        capture_exception(e)
+        raise NewsSummaryException(f"Failed to generate summary: {str(e)}")
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid summary format: {str(e)}")
+        capture_exception(e)
+        raise NewsSummaryException("Invalid summary format")
+    except Exception as e:
+        logger.error(f"Error occurred during summary generation: {str(e)}")
+        capture_exception(e)
+        raise NewsSummaryException(str(e))

--- a/backend/tests/crawler/test_base_crawler.py
+++ b/backend/tests/crawler/test_base_crawler.py
@@ -1,8 +1,9 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from pydantic import AnyHttpUrl
 from src.crawler.crawler_base import NewsCrawlerBase, News, Headline
-from src.crawler.exceptions import DomainMismatchException
+from src.crawler.exceptions import DomainMismatchException, ParseException, SaveException
+from src.logger.base import logger
 
 
 class MockNewsCrawler(NewsCrawlerBase):
@@ -13,6 +14,8 @@ class MockNewsCrawler(NewsCrawlerBase):
         return [Headline(title="Test Article", url="https://www.example.com/article")]
 
     def parse(self, url: AnyHttpUrl | str):
+        if url == "https://www.example.com/error":
+            raise ParseException("測試解析錯誤")
         return News(
             title="Test Article",
             url=url,
@@ -22,6 +25,8 @@ class MockNewsCrawler(NewsCrawlerBase):
 
     @staticmethod
     def save(news: News, db=None):
+        if news.url == "https://www.example.com/save-error":
+            raise SaveException("測試儲存錯誤")
         return True
 
 
@@ -42,11 +47,35 @@ class TestNewsCrawlerBase(unittest.TestCase):
         valid_child_url = "https://news.example.com/article"
         self.assertTrue(self.crawler._is_valid_url(valid_child_url))
 
-    def test_is_valid_url_raises_domain_mismatch(self):
+    def test_validate_and_parse_raises_domain_mismatch(self):
         invalid_url = "https://www.invalid.com/article"
-
-        with self.assertRaises(DomainMismatchException):
+        with self.assertRaises(DomainMismatchException) as context:
             self.crawler.validate_and_parse(invalid_url)
+        self.assertEqual(str(context.exception), DomainMismatchException(invalid_url).message)
+
+    def test_parse_raises_parse_exception(self):
+        error_url = "https://www.example.com/error"
+        with self.assertRaises(ParseException) as context:
+            self.crawler.parse(error_url)
+        self.assertEqual(str(context.exception), "Failed to parse news content")
+
+    def test_save_raises_save_exception(self):
+        error_news = News(
+            title="Test Article",
+            url="https://www.example.com/save-error",
+            time="2023-09-08T00:00:00",
+            content="This is the content of the article."
+        )
+        with self.assertRaises(SaveException) as context:
+            self.crawler.save(error_news)
+        self.assertEqual(str(context.exception), "Failed to save news content")
+
+    def test_validate_and_parse_logs_error(self):
+        with patch.object(logger, 'error') as mock_logger:
+            invalid_url = "https://www.invalid.com/article"
+            with self.assertRaises(DomainMismatchException):
+                self.crawler.validate_and_parse(invalid_url)
+            mock_logger.assert_called_with(f"Error validating and parsing URL {invalid_url}: {DomainMismatchException(invalid_url)}")
 
     def test_get_headline(self):
         headlines = self.crawler.get_headline(search_term="test", page=1)

--- a/backend/tests/crawler/test_udn_news_crawler.py
+++ b/backend/tests/crawler/test_udn_news_crawler.py
@@ -3,12 +3,39 @@ from unittest.mock import patch, MagicMock
 from requests.models import Response
 from sqlalchemy.orm import Session
 from src.crawler.crawler_base import NewsWithSummary
-from src.crawler.udn_crawler import  UDNCrawler
-from src.crawler.exceptions import DomainMismatchException
+from src.crawler.udn_crawler import UDNCrawler
+from src.crawler.exceptions import (
+    DomainMismatchException,
+    InvalidSearchTermException,
+    InvalidPageException,
+    ParseException,
+    SaveException
+)
+import requests
+"""
+這個測試檔案主要測試UDN爬蟲的各種功能和異常處理:
 
+1. 基本功能測試:
+- test_perform_request_success: 測試HTTP請求是否成功
+- test_perform_request_failure: 測試HTTP請求失敗的處理
+- test_fetch_news_data: 測試抓取新聞標題列表
+- test_parse_news: 測試解析單篇新聞內容
+- test_create_search_params: 測試建立搜尋參數
+- test_save_news: 測試儲存新聞
+- test_is_valid_url: 測試URL驗證
 
-
-
+2. 異常處理測試:
+- test_startup_empty_search_term: 測試空搜尋字串
+- test_get_headline_empty_search_term: 測試空搜尋字串
+- test_get_headline_invalid_page_number: 測試無效頁碼
+- test_get_headline_invalid_page_range: 測試無效頁碼範圍
+- test_perform_request_raises_parse_exception: 測試HTTP請求異常
+- test_parse_headlines_raises_parse_exception: 測試解析標題異常
+- test_parse_raises_parse_exception: 測試解析內容異常
+- test_save_raises_save_exception: 測試儲存異常
+- test_commit_changes_raises_save_exception: 測試資料庫提交異常
+- test_parse_invalid_domain: 測試無效網域
+"""
 
 class TestUDNCrawler(unittest.TestCase):
 
@@ -98,7 +125,84 @@ class TestUDNCrawler(unittest.TestCase):
         self.assertTrue(self.scraper._is_valid_url(valid_url))
         self.assertFalse(self.scraper._is_valid_url(invalid_url))
 
+    # 以下是異常處理的測試
+    def test_startup_empty_search_term(self):
+        """測試當startup()傳入空字串時,應該拋出InvalidSearchTermException"""
+        with self.assertRaises(InvalidSearchTermException):
+            self.scraper.startup("")
+
+    def test_get_headline_empty_search_term(self):
+        """測試當get_headline()傳入空字串時,應該拋出InvalidSearchTermException"""
+        with self.assertRaises(InvalidSearchTermException):
+            self.scraper.get_headline("", 1)
+
+    def test_get_headline_invalid_page_number(self):
+        """測試當get_headline()傳入負數頁碼時,應該拋出InvalidPageException"""
+        with self.assertRaises(InvalidPageException):
+            self.scraper.get_headline("test", -1)
+
+    def test_get_headline_invalid_page_range(self):
+        """測試當get_headline()傳入不合法的頁碼範圍時,應該拋出InvalidPageException"""
+        with self.assertRaises(InvalidPageException):
+            self.scraper.get_headline("test", (2, 1))  # 結束頁碼小於起始頁碼
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_perform_request_raises_parse_exception(self, mock_get):
+        """測試當HTTP請求失敗時,應該拋出ParseException"""
+        mock_get.side_effect = requests.RequestException("Network Error")
+        with self.assertRaises(ParseException):
+            self.scraper._perform_request(url="https://udn.com/news/test")
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_parse_headlines_raises_parse_exception(self, mock_get):
+        """測試當解析新聞標題失敗時,應該拋出ParseException"""
+        mock_response = MagicMock(spec=Response)
+        mock_response.json.side_effect = Exception("JSON Parse Error")
+        mock_response.url = "https://udn.com/news/test"
+        
+        with self.assertRaises(ParseException):
+            self.scraper._parse_headlines(mock_response)
+
+    @patch("src.crawler.udn_crawler.requests.get")
+    def test_parse_raises_parse_exception(self, mock_get):
+        """測試當解析新聞內容失敗時,應該拋出ParseException"""
+        mock_response = MagicMock(spec=Response)
+        mock_response.text = "<html></html>"  # 不完整的HTML
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(ParseException):
+            self.scraper.parse("https://udn.com/news/test")
+
+    @patch("src.crawler.udn_crawler.Session")
+    def test_save_raises_save_exception(self, mock_session):
+        """測試當儲存新聞失敗時,應該拋出SaveException"""
+        mock_db = MagicMock(spec=Session)
+        mock_db.add.side_effect = Exception("Database Error")
+
+        news = NewsWithSummary(
+            title="Test Title",
+            url="https://udn.com/news/test",
+            time="2023-09-08T00:00:00",
+            content="Test Content",
+            summary="Test Summary",
+            reason="Test Reason"
+        )
+
+        with self.assertRaises(SaveException):
+            self.scraper.save(news, mock_db)
+
+    @patch("src.crawler.udn_crawler.Session")
+    def test_commit_changes_raises_save_exception(self, mock_session):
+        """測試當提交資料庫變更失敗時,應該拋出SaveException並進行rollback"""
+        mock_db = MagicMock(spec=Session)
+        mock_db.commit.side_effect = Exception("Commit Error")
+
+        with self.assertRaises(SaveException):
+            self.scraper._commit_changes(mock_db)
+        mock_db.rollback.assert_called_once()
+
     def test_parse_invalid_domain(self):
+        """測試當URL不屬於UDN網域時,應該拋出DomainMismatchException"""
         invalid_url = "https://example.com/news/test-news"
         with self.assertRaises(DomainMismatchException):
             self.scraper.validate_and_parse(invalid_url)

--- a/backend/tests/database/test_database.py
+++ b/backend/tests/database/test_database.py
@@ -1,0 +1,15 @@
+# tests/test_database.py
+import pytest
+from unittest.mock import patch, MagicMock
+from src.database import session_opener
+from src.exceptions import DatabaseConnectionError
+
+def test_session_opener_raises_database_connection_error():
+    with patch('src.database.Session') as mock_session:
+        # 模擬 Session 的行為，讓它引發異常
+        mock_session.side_effect = Exception("Connection failed")
+        
+        with pytest.raises(DatabaseConnectionError) as exc_info:
+            list(session_opener())
+        
+        assert "Database connection error: Connection failed" in str(exc_info.value)

--- a/backend/tests/integration/test_news_endpoint.py
+++ b/backend/tests/integration/test_news_endpoint.py
@@ -123,7 +123,7 @@ def mock_anthropic(mocker, return_content):
 def test_search_news(mocker):
     mock_openai(mocker, "keywords")
 
-    mock_get_new_info = mocker.patch("src.news.router.get_new_info", return_value=[
+    mock_get_new_info = mocker.patch("src.news.services.get_new_info", return_value=[
          Headline(title="Test Title", url="https://udn.com/api/more/testing/news1")
     ])
 
@@ -168,7 +168,7 @@ def test_summarize_news_with_custome_model(mocker, test_token):
     # Test OpenAI model
     openai_response = json.dumps({"影響": "test impact_openai", "原因": "test reason_openai"})
     mock_openai(mocker, openai_response)
-    request_body = NewsSumaryCustomModelSchema(content="Test news content", ai_model="openai")
+    request_body = NewsSumaryCustomModelSchema(content="Test news content", llm_model="openai")
     response = client.post("/api/v1/news/news_summary_custom_model", json=request_body.dict(), headers=headers)
     assert response.status_code == 200
     json_response = response.json()
@@ -178,7 +178,7 @@ def test_summarize_news_with_custome_model(mocker, test_token):
     # Test Anthropic model 
     anthropic_response = json.dumps({"影響": "test impact_anthropic", "原因": "test reason_anthropic"})
     mock_anthropic(mocker, anthropic_response)
-    request_body = NewsSumaryCustomModelSchema(content="Test news content", ai_model="anthropic")
+    request_body = NewsSumaryCustomModelSchema(content="Test news content", llm_model="anthropic")
     response = client.post("/api/v1/news/news_summary_custom_model", json=request_body.dict(), headers=headers)
     assert response.status_code == 200
     json_response = response.json()

--- a/backend/tests/integration/test_news_endpoint.py
+++ b/backend/tests/integration/test_news_endpoint.py
@@ -1,4 +1,7 @@
 import pytest
+import unittest
+from unittest.mock import patch, MagicMock
+from src.news.services import search_news, NewsSearchException
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, StaticPool
 from sqlalchemy.orm import sessionmaker
@@ -6,12 +9,17 @@ import json
 from jose import jwt
 from src.main import app
 from src.database import Base, session_opener
-from src.models import  NewsArticle, User, user_news_table
+from src.models import NewsArticle, User, user_news_table
 from src.news.schemas import NewsSumaryRequestSchema, PromptRequest
 from src.auth.config import pwd_context
 from unittest.mock import Mock
 from src.crawler.crawler_base import Headline
 from src.news.schemas import NewsSumaryCustomModelSchema
+from src.news.exceptions import NewsSummaryException
+from src.news import router
+from src.llm_clients.exceptions import TextGenerationError
+from src.crawler.exceptions import ParseException
+
 SECRET_KEY = "1892dhianiandowqd0n"
 ALGORITHM = "HS256"
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
@@ -19,14 +27,12 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base.metadata.create_all(bind=engine)
 
-
 def override_session_opener():
     try:
         db = TestingSessionLocal()
         yield db
     finally:
         db.close()
-
 
 app.dependency_overrides[session_opener] = override_session_opener
 client = TestClient(app)
@@ -40,7 +46,6 @@ def clear_users():
 @pytest.fixture(scope="module")
 def test_user(clear_users):
     hashed_password = pwd_context.hash("testpassword")
-
     with next(override_session_opener()) as db:
         user = User(username="testuser", hashed_password=hashed_password)
         db.add(user)
@@ -48,12 +53,10 @@ def test_user(clear_users):
         db.refresh(user)
         return user
 
-
 @pytest.fixture(scope="module")
 def test_token(test_user):
     access_token = jwt.encode({"sub": test_user.username}, SECRET_KEY, algorithm=ALGORITHM)
     return access_token
-
 
 @pytest.fixture(scope="module")
 def test_articles():
@@ -78,14 +81,11 @@ def test_articles():
         db.commit()
         db.refresh(article_1)
         db.refresh(article_2)
-
         return [article_1, article_2]
-
 
 @pytest.fixture(scope="module")
 def test_user_and_articles(test_user, test_articles):
     return test_user, test_articles
-
 
 def test_read_news(test_articles):
     response = client.get("/api/v1/news/news")
@@ -95,12 +95,9 @@ def test_read_news(test_articles):
     assert json_response[0]["title"] == "Test News 2"
     assert json_response[1]["title"] == "Test News 1"
 
-
 def test_read_user_news(test_user, test_token, test_articles):
     headers = {"Authorization": f"Bearer {test_token}"}
     response = client.get("/api/v1/news/user_news", headers=headers)
-    print(test_token)
-    print(response.json())
     assert response.status_code == 200
     json_response = response.json()
     assert len(json_response) == 2
@@ -119,14 +116,11 @@ def mock_anthropic(mocker, return_content):
     mock_llm_anthropic.return_value = return_content
     return mock_llm_anthropic
 
-
 def test_search_news(mocker):
     mock_openai(mocker, "keywords")
-
     mock_get_new_info = mocker.patch("src.news.services.get_new_info", return_value=[
          Headline(title="Test Title", url="https://udn.com/api/more/testing/news1")
     ])
-
     mock_get = mocker.patch("src.crawler.udn_crawler.requests.get", return_value=mocker.Mock(
         text="""
         <html>
@@ -138,11 +132,8 @@ def test_search_news(mocker):
         </html>
         """
     ))
-
     request_body = {"prompt": "Test search prompt"}
-
     response = client.post("/api/v1/news/search_news", json=request_body)
-
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -154,7 +145,6 @@ def test_news_summary(mocker, test_token):
     headers = {"Authorization": f"Bearer {test_token}"}
     openai_response = json.dumps({"影響": "test impact", "原因": "test reason"})
     mock_openai(mocker, openai_response)
-
     request_body = NewsSumaryRequestSchema(content="Test news content")
     response = client.post("/api/v1/news/news_summary", json=request_body.dict(), headers=headers)
     assert response.status_code == 200
@@ -185,7 +175,6 @@ def test_summarize_news_with_custome_model(mocker, test_token):
     assert json_response["summary"] == "test impact_anthropic" 
     assert json_response["reason"] == "test reason_anthropic"
 
-
 def test_upvote_article(test_user_and_articles, test_token):
     user, articles = test_user_and_articles
     headers = {"Authorization": f"Bearer {test_token}"}
@@ -193,10 +182,33 @@ def test_upvote_article(test_user_and_articles, test_token):
     assert response.status_code == 200
     assert response.json()["message"] == "Article upvoted"
 
-
 def test_downvote_article(test_user_and_articles, test_token):
     user, articles = test_user_and_articles
     headers = {"Authorization": f"Bearer {test_token}"}
     response = client.post(f"/api/v1/news/{articles[0].id}/upvote", headers=headers)
     assert response.status_code == 200
     assert response.json()["message"] == "Upvote removed"
+
+class TestSearchNews(unittest.TestCase):
+    def setUp(self):
+        self.mock_extract_search_keywords = patch('src.news.services.llm_client.extract_search_keywords').start()
+        self.mock_get_new_info = patch('src.news.services.get_new_info').start()
+        self.mock_validate_and_parse = patch('src.news.services.udn_crawler.validate_and_parse').start()
+        self.addCleanup(patch.stopall) 
+    def test_search_news_text_generation_error(self):
+        self.mock_extract_search_keywords.side_effect = TextGenerationError("Keyword extraction failed")
+        with self.assertRaises(NewsSearchException) as context:
+            search_news(MagicMock())
+        self.assertIn("Failed to extract keywords", str(context.exception))
+    def test_search_news_parse_exception(self):
+        self.mock_extract_search_keywords.return_value = ["keyword"]
+        self.mock_get_new_info.return_value = [MagicMock(url="http://example.com/news1")]
+        self.mock_validate_and_parse.side_effect = ParseException("Parse failed")
+        result = search_news(MagicMock())
+        self.assertEqual(result, []) 
+    def test_search_news_general_exception(self):
+        self.mock_extract_search_keywords.return_value = ["keyword"]
+        self.mock_get_new_info.side_effect = Exception("General error")
+        with self.assertRaises(NewsSearchException) as context:
+            search_news(MagicMock())
+        self.assertIn("General error", str(context.exception))

--- a/backend/tests/integration/test_price_endpoint.py
+++ b/backend/tests/integration/test_price_endpoint.py
@@ -2,7 +2,8 @@ import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 from src.main import app
-
+from src.prices.router import get_necessities_prices
+from src.prices.exceptions import PriceRetrievalException
 client = TestClient(app)
 
 @pytest.fixture
@@ -60,13 +61,11 @@ def test_get_necessities_prices_with_query(mock_get, mock_necessities_data):
     assert data[0]["產品名稱"] == "統一瑞穗高優質鮮乳"
 
 
-# @patch("src.prices.router.requests.get")
-# def test_get_necessities_prices_error_handling(mock_get):
-#     mock_response = mock_get.return_value
-#     mock_response.status_code = 400
-#     mock_response.raise_for_status.side_effect = requests.RequestException("Error fetching data")
-
-#     response = client.get("/api/v1/prices/necessities-price")
-
-#     assert response.status_code == 400
-#     assert response.json()["detail"] == "Error fetching data"
+@patch("src.prices.router.requests.get")
+def test_get_necessities_prices_exception(mock_get):
+    mock_get.side_effect = Exception("Network error")
+    
+    with pytest.raises(PriceRetrievalException) as exc_info:
+        get_necessities_prices(category="category", commodity="commodity")
+    
+    assert "Failed to retrieve price information" in str(exc_info.value)

--- a/backend/tests/integration/test_user_endpoint.py
+++ b/backend/tests/integration/test_user_endpoint.py
@@ -7,7 +7,7 @@ from src.database import Base, session_opener
 from src.models import User
 from jose import jwt
 from src.auth.config import pwd_context
-
+from src.users.exceptions import UserException, UserAuthenticationError, UserRegistrationError
 SECRET_KEY = "1892dhianiandowqd0n"
 ALGORITHM = "HS256"
 # SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
@@ -85,3 +85,14 @@ def test_read_users_me(test_token):
     assert response.status_code == 200
     data = response.json()
     assert data["username"] == "testuser"
+def test_user_exception():
+    with pytest.raises(UserException, match="Test UserException"):
+        raise UserException("Test UserException")
+
+def test_user_authentication_error():
+    with pytest.raises(UserAuthenticationError, match="Test UserAuthenticationError"):
+        raise UserAuthenticationError("Test UserAuthenticationError")
+
+def test_user_registration_error():
+    with pytest.raises(UserRegistrationError, match="Test UserRegistrationError"):
+        raise UserRegistrationError("Test UserRegistrationError")

--- a/backend/tests/llm_clients/test_llm_clients.py
+++ b/backend/tests/llm_clients/test_llm_clients.py
@@ -3,6 +3,8 @@ import os
 from unittest.mock import patch
 
 from src.llm_clients.openai_clients import OpenAIClient
+from src.llm_clients.exceptions import MessageFormatError, TextGenerationError
+
 # 除非確認要使用真實的API進行測試(當然會因此擁有額外的開銷)，否則將RUN_REAL_API_TESTS設置為False
 RUN_REAL_API_TESTS = os.getenv("RUN_REAL_API_TESTS", "false").lower() == "true"
 
@@ -74,6 +76,37 @@ class TestOpenAIClient(unittest.TestCase):
             mock_generate_text.assert_called_once()
         except Exception as e:
             self.fail(f"測試失敗，錯誤訊息: {str(e)}")
+
+    # 測試 _llm_messages 方法在格式化訊息失敗時是否正確拋出 MessageFormatError
+    def test_llm_messages_format_error(self):
+        with self.assertRaises(MessageFormatError):
+            self.client._llm_messages(system_content=None, user_content=None)
+
+
+    def test_generate_text_error(self):
+        with self.assertRaises(TextGenerationError):
+            self.client._generate_text("", "")
+
+    # 測試異常情況下的 evaluate_relevance 方法
+    @patch('src.llm_clients.Templete.LLMClientTemplate._generate_text')
+    def test_evaluate_relevance_error(self, mock_generate_text):
+        mock_generate_text.side_effect = TextGenerationError("生成文字失敗")
+        with self.assertRaises(TextGenerationError):
+            self.client.evaluate_relevance("測試標題")
+
+    # 測試異常情況下的 generate_summary 方法
+    @patch('src.llm_clients.Templete.LLMClientTemplate._generate_text')
+    def test_generate_summary_error(self, mock_generate_text):
+        mock_generate_text.side_effect = TextGenerationError("生成摘要失敗")
+        with self.assertRaises(TextGenerationError):
+            self.client.generate_summary("測試內容")
+
+    # 測試異常情況下的 extract_search_keywords 方法
+    @patch('src.llm_clients.Templete.LLMClientTemplate._generate_text')
+    def test_extract_search_keywords_error(self, mock_generate_text):
+        mock_generate_text.side_effect = TextGenerationError("關鍵字提取失敗")
+        with self.assertRaises(TextGenerationError):
+            self.client.extract_search_keywords("測試內容")
 
 
 if __name__ == '__main__':

--- a/backend/tests/llm_clients/test_llm_clients.py
+++ b/backend/tests/llm_clients/test_llm_clients.py
@@ -77,10 +77,10 @@ class TestOpenAIClient(unittest.TestCase):
         except Exception as e:
             self.fail(f"測試失敗，錯誤訊息: {str(e)}")
 
-    # 測試 _llm_messages 方法在格式化訊息失敗時是否正確拋出 MessageFormatError
-    def test_llm_messages_format_error(self):
+    # 測試 _generate_mpi_messages 方法在格式化訊息失敗時是否正確拋出 MessageFormatError
+    def test_generate_mpi_messages_format_error(self):
         with self.assertRaises(MessageFormatError):
-            self.client._llm_messages(system_content=None, user_content=None)
+            self.client._generate_mpi_messages(system_content=None, user_content=None)
 
 
     def test_generate_text_error(self):

--- a/backend/tests/llm_clients/test_llm_clients.py
+++ b/backend/tests/llm_clients/test_llm_clients.py
@@ -49,40 +49,21 @@ class TestOpenAIClient(unittest.TestCase):
 
             self.assertEqual(result, 'high')
 
-            mock_generate_text.assert_called_once_with(
-                messages=[
-                    {
-                        "role": "system",
-                        "content":"你是一個關聯度評估機器人，請評估新聞標題是否與「民生用品的價格變化」相關，並給予\"high\"、\"medium\"、\"low\"評價。(僅需回答\"high\"、\"medium\"、\"low\"三個詞之一)",
-                    },
-                    {"role": "user", "content": "食品價格上漲"},
-                ]
-            )
+            mock_generate_text.assert_called_once()
         except Exception as e:
             self.fail(f"測試失敗，錯誤訊息: {str(e)}")
 
-    @patch('src.llm_clients.openai_clients.OpenAIClient._generate_text')
+    @patch('src.llm_clients.Templete.LLMClientTemplate._generate_text')
     def test_generate_summary(self, mock_generate_text):
         try:
             mock_generate_text.return_value = '{"影響": "影響描述", "原因": "原因描述"}'
-
             result = self.client.generate_summary("一篇新聞內容")
-
             self.assertEqual(result, '{"影響": "影響描述", "原因": "原因描述"}')
-
-            mock_generate_text.assert_called_once_with(
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "你是一個新聞摘要生成機器人，請統整新聞中提及的影響及主要原因 (影響、原因各50個字請以json格式回答請不要有```json {\"影響\": \"...\", \"原因\": \"...\"})",
-                    },
-                    {"role": "user", "content": "一篇新聞內容"},
-                ]
-            )
+            mock_generate_text.assert_called_once()
         except Exception as e:
             self.fail(f"測試失敗，錯誤訊息: {str(e)}")
 
-    @patch('src.llm_clients.openai_clients.OpenAIClient._generate_text')
+    @patch('src.llm_clients.Templete.LLMClientTemplate._generate_text')
     def test_extract_search_keywords(self, mock_generate_text):
         try:
             mock_generate_text.return_value = '食品 價格'
@@ -90,16 +71,7 @@ class TestOpenAIClient(unittest.TestCase):
             result = self.client.extract_search_keywords("一段希望看到的新聞文字")
 
             self.assertEqual(result, '食品 價格')
-
-            mock_generate_text.assert_called_once_with(
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "你是一個關鍵字提取機器人，用戶將會輸入一段文字，表示其希望看見的新聞內容，請提取出用戶希望看見的關鍵字，請截取最重要的關鍵字即可，避免出現「新聞」、「資訊」等混淆搜尋引擎的字詞。(僅須回答關鍵字，若有多個關鍵字，請以空格分隔)",
-                    },
-                    {"role": "user", "content": "一段希望看到的新聞文字"},
-                ]
-            )
+            mock_generate_text.assert_called_once()
         except Exception as e:
             self.fail(f"測試失敗，錯誤訊息: {str(e)}")
 


### PR DESCRIPTION
## purpose
根據先前的建議進行調整，並新增例外測試
## details
### ``backend/src/crawler/udn_crawler.py``
 db 目前只定義了 NewsArticle 和 User 2 種資料類型，傳入 NewsWithSummary 類型的物件會引發錯誤，更動資料類型
### ``backend/src/database.py``
新增錯誤處理，透過 logger 和 Sentry 記錄資料庫連線錯誤
### ``backend/src/llm_clients/Templete.py``
- 將``generate_summary``、``evaluate_relevance``、``extract_search_keywords``簡化
### ``backend/src/llm_clients/anthropic_clients.py``
砍掉應該沒必要的exceptions
### ``backend/src/llm_clients/llm_base.py``
砍掉class MessagePassingInterface(BaseModel)因為感覺沒有必要性
### ``backend/src/news/router.py``
把functions整理到services裡增加可讀性
### ``backend/src/news/schemas.py``
``ai_model: str``->``llm_model: Literal["openai", "anthropic"]``
讓 FastAPI 幫忙驗證 HTTP request 並簡化判斷邏輯

